### PR TITLE
do not crash on iOS when someone ask for tracking enabled

### DIFF
--- a/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/FalconmetricsFlutterPlugin.swift
+++ b/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/FalconmetricsFlutterPlugin.swift
@@ -40,6 +40,12 @@ public class FalconmetricsFlutterPlugin: NSObject, FlutterPlugin {
             } catch {
                 result(FlutterError(code: "PARSE_ERROR", message: "Failed to parse TrackingEvent", details: error.localizedDescription))
             }
+    case "setTrackingEnabled":
+        // This function only works on android and shouldn't do anything on iOS because we depend on skad
+        result(nil)
+    case "isTrackingEnabled":
+        // This function only works on android and shouldn't do anything on iOS because we depend on skad
+        result(true)
     default:
       result(FlutterMethodNotImplemented)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "setTrackingEnabled" and "isTrackingEnabled" method calls on iOS, which now return default responses for compatibility. These methods are documented as Android-only and do not affect iOS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->