### PR TITLE
feat: add currency and revenue in cents to custom event

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ FalconMetrics uses SKAdNetwork for iOS. No additional setup is required as the S
 Add the following to your App's `Podfile`:
 
 ```ruby
-source 'https://github.com/falconmetrics/falconmetrics-ios-pods.git' 
+# Pointing to the official CocoaPods master repository
+source 'https://cdn.cocoapods.org/'
+# Pointing to the FalconMetrics private repository
+source 'https://github.com/falconmetrics/falconmetrics-ios-pods.git'
 ```
 
 ## Usage
@@ -128,6 +131,8 @@ await falconMetrics.trackEvent(
 
 You can also create a custom event but make sure to use the same event name as the one you use in your ad network.
 
+Optionally you can add a currency and revenue in cents to the custom event. The revenue will be recorded as revenue to the ad network.
+
 ```dart
 await falconMetrics.trackEvent(
   event: CustomEvent(
@@ -135,6 +140,8 @@ await falconMetrics.trackEvent(
     attributes: {
       'attribute_name': 'attribute_value',
     },
+    currency: 'USD',
+    revenueInCents: 1099,
   ),
 );
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,7 @@ android {
     }
 
     dependencies {
-        implementation 'io.falconmetrics:sdk:0.5.0'
+        implementation 'io.falconmetrics:sdk:0.5.1'
         implementation 'com.google.protobuf:protobuf-javalite:3.25.3'
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")

--- a/android/src/main/kotlin/io/falconmetrics/falconmetrics_flutter/ConvertProtobuf.kt
+++ b/android/src/main/kotlin/io/falconmetrics/falconmetrics_flutter/ConvertProtobuf.kt
@@ -79,7 +79,9 @@ fun convertTrackingEvent(event: Event.TrackingEvent): TrackingEvent {
 
             CustomEvent(
                 eventName = event.customEvent.eventName,
-                attributes = attributes
+                attributes = attributes,
+                currency = event.customEvent.currency,
+                revenueInCents = event.customEvent.revenueInCents
             )
         }
 

--- a/android/src/test/kotlin/io/falconmetrics/falconmetrics_flutter/ConvertProtobufTest.kt
+++ b/android/src/test/kotlin/io/falconmetrics/falconmetrics_flutter/ConvertProtobufTest.kt
@@ -116,6 +116,56 @@ class ConvertProtobufEventTest {
     }
 
     @Test
+    fun `It should return Custom event with revenue`() {
+        val attributeValue1 = Event.AttributeValue.newBuilder()
+            .setStringValue("my_value")
+            .build()
+
+        val attributeValue2 = Event.AttributeValue.newBuilder()
+            .setIntValue(1000)
+            .build()
+
+        val attributeValue3 = Event.AttributeValue.newBuilder()
+            .setBoolValue(false)
+            .build()
+
+        val attributeValue4 = Event.AttributeValue.newBuilder()
+            .setDoubleValue(3.14)
+            .build()
+
+        val event = Event.CustomEvent.newBuilder()
+            .setEventName("my_custom_event")
+            .setCurrency("USD")
+            .setRevenueInCents(1000)
+            .putAllAttributes(
+                mapOf(
+                    "key1" to attributeValue1,
+                    "key2" to attributeValue2,
+                    "key3" to attributeValue3,
+                    "key4" to attributeValue4
+                )
+            )
+            .build()
+
+        val trackingEvent = Event.TrackingEvent.newBuilder()
+            .setCustomEvent(event)
+            .build()
+
+        val result = convertTrackingEvent(trackingEvent)
+
+        assertTrue(result is CustomEvent)
+        result as CustomEvent
+        assertEquals("my_custom_event", result.eventName)
+        assertEquals("USD", result.currency)
+        assertEquals(1000, result.revenueInCents)
+        assertEquals(
+            mapOf("key1" to "my_value", "key2" to 1000, "key3" to false, "key4" to 3.14),
+            result.attributes
+        )
+    }
+
+
+    @Test
     fun `convertTrackingEvent should return PurchaseEvent when event is PURCHASE`() {
         // Arrange
         val purchaseEvent = Event.PurchaseEvent.newBuilder()

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -9,7 +9,10 @@ project 'Runner', {
   'Profile' => :release,
   'Release' => :release,
 }
-source 'https://github.com/falconmetrics/falconmetrics-ios-pods.git' 
+# Pointing to the official CocoaPods master repository
+source 'https://cdn.cocoapods.org/'
+# Pointing to the FalconMetrics private repository
+source 'https://github.com/falconmetrics/falconmetrics-ios-pods.git'
 
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - FalconMetrics (0.4.0)
+  - FalconMetrics (0.4.1)
   - falconmetrics_flutter (0.5.0):
-    - FalconMetrics (= 0.4.0)
+    - FalconMetrics (= 0.4.1)
     - Flutter
     - SwiftProtobuf (~> 1.27.0)
   - Flutter (1.0.0)
@@ -29,12 +29,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  FalconMetrics: 67661bbd3733106ecae0fe41f7ed66a05195b83c
-  falconmetrics_flutter: 29077edb765d54d7131df8850bdd1ffc3cee0496
+  FalconMetrics: 83b1a0541ab8635f931e06fc8718fab12e22ae21
+  falconmetrics_flutter: d8d356f824145b6699f449f3f809c7f52a79a8bb
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   SwiftProtobuf: b109bd17979d7993a84da14b1e1fdd8b0ded934a
 
-PODFILE CHECKSUM: e268ddf99be6d8582c768678f9e9ef1b67c18d0d
+PODFILE CHECKSUM: e1f02846647ac9304fa2c361ba815f6581cb85d4
 
 COCOAPODS: 1.16.2

--- a/ios/falconmetrics_flutter.podspec
+++ b/ios/falconmetrics_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin for FalconMetrics, a comprehensive mobile app attribution solutio
   s.source           = { :path => '.' }
   s.dependency 'Flutter'
   s.dependency 'SwiftProtobuf', '~> 1.27.0'
-  s.dependency 'FalconMetrics', '0.4.0'
+  s.dependency 'FalconMetrics', '0.4.1'
   s.source_files = 'falconmetrics_flutter/Sources/**/*.{swift}'
   
   s.platform = :ios, '13.0'

--- a/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/ConvertProtobuf.swift
+++ b/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/ConvertProtobuf.swift
@@ -48,6 +48,8 @@ func convertTrackingEvent(event: Pb_TrackingEvent) throws -> FalconMetrics.BaseE
         return FalconMetricsSdk.shared.createCustomEventBuilder()
             .withAttributes(event.customEvent.attributes)
             .withEventName(event.customEvent.eventName)
+            .withCurrency(event.customEvent.currency)
+            .withRevenueInCents(Int(event.customEvent.revenueInCents))
 
     @unknown default:
         throw NSError(domain: "TrackingError", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unknown event case"])

--- a/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/event.pb.swift
+++ b/ios/falconmetrics_flutter/Sources/falconmetrics_flutter/event.pb.swift
@@ -282,9 +282,30 @@ struct Pb_CustomEvent: Sendable {
   /// Values are restricted to primitive types (String, Int, Double, Boolean, etc.)
   var attributes: Dictionary<String,Pb_AttributeValue> = [:]
 
+  var currency: String {
+    get {return _currency ?? String()}
+    set {_currency = newValue}
+  }
+  /// Returns true if `currency` has been explicitly set.
+  var hasCurrency: Bool {return self._currency != nil}
+  /// Clears the value of `currency`. Subsequent reads from it will return its default value.
+  mutating func clearCurrency() {self._currency = nil}
+
+  var revenueInCents: Int32 {
+    get {return _revenueInCents ?? 0}
+    set {_revenueInCents = newValue}
+  }
+  /// Returns true if `revenueInCents` has been explicitly set.
+  var hasRevenueInCents: Bool {return self._revenueInCents != nil}
+  /// Clears the value of `revenueInCents`. Subsequent reads from it will return its default value.
+  mutating func clearRevenueInCents() {self._revenueInCents = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _currency: String? = nil
+  fileprivate var _revenueInCents: Int32? = nil
 }
 
 /// Union type to represent primitive values for attributes
@@ -702,6 +723,8 @@ extension Pb_CustomEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "event_name"),
     2: .same(proto: "attributes"),
+    3: .same(proto: "currency"),
+    4: .standard(proto: "revenue_in_cents"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -712,24 +735,38 @@ extension Pb_CustomEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.eventName) }()
       case 2: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Pb_AttributeValue>.self, value: &self.attributes) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self._currency) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self._revenueInCents) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.eventName.isEmpty {
       try visitor.visitSingularStringField(value: self.eventName, fieldNumber: 1)
     }
     if !self.attributes.isEmpty {
       try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Pb_AttributeValue>.self, value: self.attributes, fieldNumber: 2)
     }
+    try { if let v = self._currency {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._revenueInCents {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Pb_CustomEvent, rhs: Pb_CustomEvent) -> Bool {
     if lhs.eventName != rhs.eventName {return false}
     if lhs.attributes != rhs.attributes {return false}
+    if lhs._currency != rhs._currency {return false}
+    if lhs._revenueInCents != rhs._revenueInCents {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -81,7 +81,12 @@ class SubscriptionEvent extends TrackingEvent {
 
 /// Custom event to track a custom event
 class CustomEvent extends TrackingEvent {
-  const CustomEvent({required this.eventName, this.attributes});
+  const CustomEvent({
+    required this.eventName,
+    this.attributes,
+    this.currency,
+    this.revenueInCents,
+  });
 
   /// The name of the event make sure it matches the event in your ad network.
   final String eventName;
@@ -92,8 +97,20 @@ class CustomEvent extends TrackingEvent {
   /// for example: String, Int, Double, Boolean, etc.
   final Map<String, Object>? attributes;
 
+  /// The revenue in cents or in the lowest currency unit.
+  ///
+  /// For example, if the currency is USD, in case the revenue is $10.99, the
+  /// revenue in cents would be 1099. In case of single digit currencies, such as
+  /// the currency is Yen (JPY), the revenue would be 109 if the revenue is 109 Yen.
+  final int? revenueInCents;
+
+  /// The currency of the revenue in ISO 4217 format
+  ///
+  /// For example, USD, JPY, EUR, etc.
+  final String? currency;
+
   @override
-  List<Object?> get props => [eventName, attributes];
+  List<Object?> get props => [eventName, attributes, revenueInCents, currency];
 }
 
 class PurchaseEvent extends TrackingEvent {

--- a/lib/src/generated/event.pb.dart
+++ b/lib/src/generated/event.pb.dart
@@ -589,10 +589,14 @@ class CustomEvent extends $pb.GeneratedMessage {
   factory CustomEvent({
     $core.String? eventName,
     $core.Iterable<$core.MapEntry<$core.String, AttributeValue>>? attributes,
+    $core.String? currency,
+    $core.int? revenueInCents,
   }) {
     final result = create();
     if (eventName != null) result.eventName = eventName;
     if (attributes != null) result.attributes.addEntries(attributes);
+    if (currency != null) result.currency = currency;
+    if (revenueInCents != null) result.revenueInCents = revenueInCents;
     return result;
   }
 
@@ -617,6 +621,9 @@ class CustomEvent extends $pb.GeneratedMessage {
         valueCreator: AttributeValue.create,
         valueDefaultOrMaker: AttributeValue.getDefault,
         packageName: const $pb.PackageName('pb'))
+    ..aOS(3, _omitFieldNames ? '' : 'currency')
+    ..a<$core.int>(
+        4, _omitFieldNames ? '' : 'revenueInCents', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -653,6 +660,24 @@ class CustomEvent extends $pb.GeneratedMessage {
   /// Values are restricted to primitive types (String, Int, Double, Boolean, etc.)
   @$pb.TagNumber(2)
   $pb.PbMap<$core.String, AttributeValue> get attributes => $_getMap(1);
+
+  @$pb.TagNumber(3)
+  $core.String get currency => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set currency($core.String value) => $_setString(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasCurrency() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCurrency() => $_clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get revenueInCents => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set revenueInCents($core.int value) => $_setSignedInt32(3, value);
+  @$pb.TagNumber(4)
+  $core.bool hasRevenueInCents() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRevenueInCents() => $_clearField(4);
 }
 
 enum AttributeValue_Value {

--- a/lib/src/generated/event.pbjson.dart
+++ b/lib/src/generated/event.pbjson.dart
@@ -279,8 +279,30 @@ const CustomEvent$json = {
       '6': '.pb.CustomEvent.AttributesEntry',
       '10': 'attributes'
     },
+    {
+      '1': 'currency',
+      '3': 3,
+      '4': 1,
+      '5': 9,
+      '9': 0,
+      '10': 'currency',
+      '17': true
+    },
+    {
+      '1': 'revenue_in_cents',
+      '3': 4,
+      '4': 1,
+      '5': 5,
+      '9': 1,
+      '10': 'revenueInCents',
+      '17': true
+    },
   ],
   '3': [CustomEvent_AttributesEntry$json],
+  '8': [
+    {'1': '_currency'},
+    {'1': '_revenue_in_cents'},
+  ],
 };
 
 @$core.Deprecated('Use customEventDescriptor instead')
@@ -303,9 +325,11 @@ const CustomEvent_AttributesEntry$json = {
 /// Descriptor for `CustomEvent`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List customEventDescriptor = $convert.base64Decode(
     'CgtDdXN0b21FdmVudBIdCgpldmVudF9uYW1lGAEgASgJUglldmVudE5hbWUSPwoKYXR0cmlidX'
-    'RlcxgCIAMoCzIfLnBiLkN1c3RvbUV2ZW50LkF0dHJpYnV0ZXNFbnRyeVIKYXR0cmlidXRlcxpR'
-    'Cg9BdHRyaWJ1dGVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSKAoFdmFsdWUYAiABKAsyEi5wYi'
-    '5BdHRyaWJ1dGVWYWx1ZVIFdmFsdWU6AjgB');
+    'RlcxgCIAMoCzIfLnBiLkN1c3RvbUV2ZW50LkF0dHJpYnV0ZXNFbnRyeVIKYXR0cmlidXRlcxIf'
+    'CghjdXJyZW5jeRgDIAEoCUgAUghjdXJyZW5jeYgBARItChByZXZlbnVlX2luX2NlbnRzGAQgAS'
+    'gFSAFSDnJldmVudWVJbkNlbnRziAEBGlEKD0F0dHJpYnV0ZXNFbnRyeRIQCgNrZXkYASABKAlS'
+    'A2tleRIoCgV2YWx1ZRgCIAEoCzISLnBiLkF0dHJpYnV0ZVZhbHVlUgV2YWx1ZToCOAFCCwoJX2'
+    'N1cnJlbmN5QhMKEV9yZXZlbnVlX2luX2NlbnRz');
 
 @$core.Deprecated('Use attributeValueDescriptor instead')
 const AttributeValue$json = {

--- a/lib/src/platform/event_proto_converter.dart
+++ b/lib/src/platform/event_proto_converter.dart
@@ -74,6 +74,8 @@ class EventProtoConverter {
     return pb.CustomEvent(
       eventName: event.eventName,
       attributes: attributes.entries,
+      currency: event.currency,
+      revenueInCents: event.revenueInCents,
     );
   }
 

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -56,6 +56,9 @@ message CustomEvent {
   // Attributes associated with the event
   // Values are restricted to primitive types (String, Int, Double, Boolean, etc.)
   map<string, AttributeValue> attributes = 2;
+
+  optional string currency = 3;
+  optional int32 revenue_in_cents = 4;
 }
 
 // Union type to represent primitive values for attributes

--- a/test/platform/event_proto_converter_test.dart
+++ b/test/platform/event_proto_converter_test.dart
@@ -145,6 +145,41 @@ void main() {
       expect(customEvent.attributes['attribute2']?.intValue, equals(123));
       expect(customEvent.attributes['attribute3']?.boolValue, equals(true));
     });
+    test('converts CustomEvent correctly with revenue', () {
+      // Arrange
+      final event = CustomEvent(
+        eventName: 'custom_event',
+        attributes: {
+          'attribute1': 'value1',
+          'attribute2': 123,
+          'attribute3': true,
+        },
+        currency: 'USD',
+        revenueInCents: 1099,
+      );
+
+      // Act
+      final protoEvent = converter.convert(event);
+
+      // Assert
+      expect(protoEvent.hasCustomEvent(), isTrue);
+      expect(
+        protoEvent.whichEvent(),
+        equals(pb.TrackingEvent_Event.customEvent),
+      );
+
+      final customEvent = protoEvent.customEvent;
+      expect(customEvent.eventName, equals('custom_event'));
+      expect(customEvent.attributes.length, equals(3));
+      expect(
+        customEvent.attributes['attribute1']?.stringValue,
+        equals('value1'),
+      );
+      expect(customEvent.attributes['attribute2']?.intValue, equals(123));
+      expect(customEvent.attributes['attribute3']?.boolValue, equals(true));
+      expect(customEvent.currency, equals('USD'));
+      expect(customEvent.revenueInCents, equals(1099));
+    });
 
     test('Is throws error when customevent has incorrect attribute type', () {
       // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom events now support optional currency and revenue (in cents) fields, allowing more detailed event tracking.

* **Bug Fixes**
  * None.

* **Documentation**
  * Updated setup instructions for CocoaPods and improved documentation on creating custom events with currency and revenue fields.

* **Chores**
  * Upgraded FalconMetrics SDK dependencies for both Android and iOS to the latest versions.
  * Enhanced test coverage to verify correct handling of currency and revenue fields in custom events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->